### PR TITLE
fix(bootstrap): update default repo URL to ZeTo12/agentic-delivery-os

### DIFF
--- a/doc/changes/2026-04/2026-04-30--GH-3--fix-bootstrap-repo-url/chg-GH-3-pm-notes.yaml
+++ b/doc/changes/2026-04/2026-04-30--GH-3--fix-bootstrap-repo-url/chg-GH-3-pm-notes.yaml
@@ -1,0 +1,29 @@
+change_id: GH-3
+title: "fix: update bootstrap.py default repo URL to ZeTo12/agentic-delivery-os"
+phases:
+  clarify_scope:      { started: "2026-04-30", completed: "2026-04-30" }
+  specification:      { started: "2026-04-30", completed: "2026-04-30" }
+  test_planning:      { started: "2026-04-30", completed: "2026-04-30" }
+  delivery_planning:  { started: "2026-04-30", completed: "2026-04-30" }
+  delivery:           { started: "2026-04-30", completed: null }
+  system_spec_update: { started: null, completed: null }
+  review_fix:         { started: null, completed: null }
+  quality_gates:      { started: null, completed: null }
+  dod_check:          { started: null, completed: null }
+  pr_creation:        { started: null, completed: null, url: null }
+
+decisions:
+  - text: "Option C chosen — hardcode ZeTo12 fork URL now; revert to upstream URL manually before any upstream PR. No token substitution or dynamic detection needed at this stage."
+    date: "2026-04-30"
+
+open_questions: []
+
+blockers: []
+
+notes:
+  - text: "Tiny single-file fix. Skipping formal spec/test-plan/plan artifacts — scope is one line change in bootstrap.py plus docstring update."
+    type: info
+    date: "2026-04-30"
+  - text: "Root cause: bootstrap.py was written with upstream URL hardcoded. Discovered when testing Windows one-liner after merging GH-1."
+    type: info
+    date: "2026-04-30"

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -4,12 +4,15 @@
 Clones the ADOS repo and runs install.py --global.  This file has NO dependency
 on ados_lib and can be piped directly from the internet:
 
-    curl -fsSL https://raw.githubusercontent.com/juliusz-cwiakalski/agentic-delivery-os/main/scripts/bootstrap.py | python3 -
+    curl -fsSL https://raw.githubusercontent.com/ZeTo12/agentic-delivery-os/main/scripts/bootstrap.py | python3 -
 
 Windows PowerShell:
-    irm https://raw.githubusercontent.com/juliusz-cwiakalski/agentic-delivery-os/main/scripts/bootstrap.py | python -
+    irm https://raw.githubusercontent.com/ZeTo12/agentic-delivery-os/main/scripts/bootstrap.py | python -
 
 Requirements: Python >= 3.8, git
+
+Note: If submitting a PR to the upstream project (juliusz-cwiakalski/agentic-delivery-os),
+revert the default ADOS_REPO_URL below and the URLs above back to the upstream repo.
 """
 from __future__ import annotations
 
@@ -28,7 +31,7 @@ def main() -> None:
 
     repo_url = os.environ.get(
         "ADOS_REPO_URL",
-        "https://github.com/juliusz-cwiakalski/agentic-delivery-os.git",
+        "https://github.com/ZeTo12/agentic-delivery-os.git",
     )
     ados_home = Path(os.environ.get("ADOS_HOME", str(Path.home() / ".ados")))
     repo_dir = Path(os.environ.get("ADOS_REPO_DIR", str(ados_home / "repo")))


### PR DESCRIPTION
bootstrap.py was hardcoded to upstream repo URL, causing install.py not found error when run from this fork. Also adds a note in the docstring reminding to revert the URL before any upstream PR.